### PR TITLE
[#22] 배송요청 API 구현

### DIFF
--- a/service/delivery/delivery_dto/src/main/java/com/sparta/delivery/dto/StateUpdateDto.java
+++ b/service/delivery/delivery_dto/src/main/java/com/sparta/delivery/dto/StateUpdateDto.java
@@ -1,0 +1,13 @@
+package com.sparta.delivery.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StateUpdateDto {
+  private String stateName;
+}

--- a/service/delivery/delivery_server/build.gradle
+++ b/service/delivery/delivery_server/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     //implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'

--- a/service/delivery/delivery_server/build.gradle
+++ b/service/delivery/delivery_server/build.gradle
@@ -23,6 +23,7 @@ ext {
 
 dependencies {
     implementation project(':common:domain')
+    implementation project(':service:hub:hub_dto')
     implementation project(':service:delivery:delivery_dto')
     implementation project(':service:gateway:gateway_domain')
 

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/DeliveryServerApplication.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/DeliveryServerApplication.java
@@ -2,8 +2,10 @@ package com.sparta.delivery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class DeliveryServerApplication {
 
   public static void main(String[] args) {

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryFacadeService.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryFacadeService.java
@@ -1,0 +1,35 @@
+package com.sparta.delivery.application;
+
+import com.sparta.commons.domain.exception.BusinessException;
+import com.sparta.delivery.domain.model.Delivery;
+import com.sparta.delivery.infrastructure.client.HubClient;
+import com.sparta.delivery.presentation.dto.DeliveryResponse;
+import com.sparta.delivery.presentation.exception.DeliveryErrorCode;
+import com.sparta.hub.dto.InterHubResponse;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "DeliveryFacadeService")
+public class DeliveryFacadeService {
+  private DeliveryService deliveryService;
+  private DeliveryRouteService deliveryRouteService;
+  private HubClient hubClient;
+
+  @Transactional
+  public DeliveryResponse requestDeliveryAndCreateRoute(UUID deliveryId){
+    Delivery delivery = deliveryService.updateDeliveryState(deliveryId);
+    InterHubResponse deliveryRoute =
+        hubClient
+            .getDeliveryRoutes(delivery.getDepartureHubId(), delivery.getArrivalHubId())
+            .orElseThrow(() -> new BusinessException(DeliveryErrorCode.INTERNAL_SERVER_ERROR));
+    delivery.setEstimatedDeliveryData(deliveryRoute.getElapsedTime(), deliveryRoute.getDistance());
+    deliveryRouteService.createDeliveryRoute(delivery, deliveryRoute.getStops());
+    return DeliveryResponse.fromEntity(delivery);
+  }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryRouteService.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryRouteService.java
@@ -1,0 +1,34 @@
+package com.sparta.delivery.application;
+
+import com.sparta.delivery.domain.model.Delivery;
+import com.sparta.delivery.domain.model.DeliveryRoute;
+import com.sparta.delivery.infrastructure.repository.DeliveryRouteRepository;
+import com.sparta.hub.dto.InterHubStopResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryRouteService {
+  private final DeliveryRouteRepository deliveryRouteRepository;
+
+  public void createDeliveryRoute(Delivery delivery, List<InterHubStopResponse> interHubs) {
+    List<DeliveryRoute> routes =
+        interHubs.stream()
+            .map(
+                interHub ->
+                    DeliveryRoute.builder()
+                        .delivery(delivery)
+                        .sequence(interHub.getSequence())
+                        .departureHubId(interHub.getDepartureHubId())
+                        .arrivalHubId(interHub.getArrivalHubId())
+                        .estimatedDistance(interHub.getDistance())
+                        .estimatedElapsedTime(interHub.getElapsedTime())
+                        .build())
+            .collect(Collectors.toList());
+    deliveryRouteRepository.saveAll(routes);
+    delivery.setDeliveryRoutes(routes);
+  }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryService.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryService.java
@@ -1,7 +1,11 @@
 package com.sparta.delivery.application;
 
+import com.sparta.commons.domain.exception.BusinessException;
+import com.sparta.delivery.domain.model.Delivery;
+import com.sparta.delivery.domain.model.State.DeliveryState;
 import com.sparta.delivery.infrastructure.repository.DeliveryRepository;
-import com.sparta.delivery.infrastructure.repository.DeliveryRouteRepository;
+import com.sparta.delivery.presentation.exception.DeliveryErrorCode;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,33 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeliveryService {
   private final DeliveryRepository deliveryRepository;
-  private final DeliveryRouteRepository deliveryRouteRepository;
 
-  //  public DeliveryDto create(UUID shippingManagerId, String shippingManagerSlackId, String
-  // shippingAddress, Order order, List<InterHubDto> interHubs){
-  // UUID departureHubId = interHubs.get(0).getHubId();
-  // UUID arrivalHubId = interHubs.get(interHubs.size() - 1).getHubId;
-  //    Delivery delivery = Delivery.builder()
-  //        .departureHubId(departureHubId)
-  //        .arrivalHubId(arrivalHubId)
-  //        .order(order)
-  //        .shippingManagerId(shippingManagerId)
-  //        .shippingManagerSlackId(shippingManagerSlackId)
-  //        .shippingAddress(shippingAddress)
-  //        .build();
-  //    deliveryRepository.save(delivery);
-  //    List<DeliveryRoute> routes = interHubs.stream()
-  //        .map(interHub -> DeliveryRoute.builder()
-  //            .departureHubId(interHub.getDepartureHubId)
-  //            .arrivalHubId(interHub.getArrivalHubId)
-  //            .delivery(delivery)
-  //            .expectedElapsedTime(interHub.getElapsedTime)
-  //            .expectedDistance(interHub.getDistance)
-  //            .sequence())
-  //        .collect(Collectors.toList());
-  //    deliveryRouteRepository.saveAll(routes);
-  //    delivery.setDeliveryRoutes(routes);
-
-  //    return DeliveryDto.
-  // }
+  public Delivery updateDeliveryState(UUID deliveryId) {
+    Delivery delivery =
+        deliveryRepository
+            .findByDeliveryId(deliveryId)
+            .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY));
+    delivery.updateDeliveryState(DeliveryState.REQUESTED);
+    return delivery;
+  }
 }

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryService.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryService.java
@@ -1,0 +1,43 @@
+package com.sparta.delivery.application;
+
+import com.sparta.delivery.infrastructure.repository.DeliveryRepository;
+import com.sparta.delivery.infrastructure.repository.DeliveryRouteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeliveryService {
+  private final DeliveryRepository deliveryRepository;
+  private final DeliveryRouteRepository deliveryRouteRepository;
+
+  //  public DeliveryDto create(UUID shippingManagerId, String shippingManagerSlackId, String
+  // shippingAddress, Order order, List<InterHubDto> interHubs){
+  // UUID departureHubId = interHubs.get(0).getHubId();
+  // UUID arrivalHubId = interHubs.get(interHubs.size() - 1).getHubId;
+  //    Delivery delivery = Delivery.builder()
+  //        .departureHubId(departureHubId)
+  //        .arrivalHubId(arrivalHubId)
+  //        .order(order)
+  //        .shippingManagerId(shippingManagerId)
+  //        .shippingManagerSlackId(shippingManagerSlackId)
+  //        .shippingAddress(shippingAddress)
+  //        .build();
+  //    deliveryRepository.save(delivery);
+  //    List<DeliveryRoute> routes = interHubs.stream()
+  //        .map(interHub -> DeliveryRoute.builder()
+  //            .departureHubId(interHub.getDepartureHubId)
+  //            .arrivalHubId(interHub.getArrivalHubId)
+  //            .delivery(delivery)
+  //            .expectedElapsedTime(interHub.getElapsedTime)
+  //            .expectedDistance(interHub.getDistance)
+  //            .sequence())
+  //        .collect(Collectors.toList());
+  //    deliveryRouteRepository.saveAll(routes);
+  //    delivery.setDeliveryRoutes(routes);
+
+  //    return DeliveryDto.
+  // }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/Delivery.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/Delivery.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -30,6 +31,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_delete is false")
 @SQLDelete(sql = "UPDATE p_deliveries SET deleted_at = NOW() where delivery_id = ?")
+@Getter
 public class Delivery extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -61,8 +63,11 @@ public class Delivery extends BaseEntity {
   @OneToMany(mappedBy = "delivery", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<DeliveryRoute> routes = new ArrayList<>();
 
+  private long estimatedElapsedTime;
+  private double estimatedDistance;
+
   @Column(name = "shipping_start_date")
-  private LocalDateTime shippingStartDate; //TODO :: 배송요청에서 허브이동중으로 변경되었을때 초기화
+  private LocalDateTime shippingStartDate; //TODO :: 배송대기에서 배송요청으로 변경되었을때 초기화
 
   @Column(name = "shipping_end_date")
   private LocalDateTime shippingEndDate; //TODO :: 업체배송중에서 업체배송완료로 변경되었을때 초기화
@@ -83,6 +88,11 @@ public class Delivery extends BaseEntity {
     this.shippingAddress = shippingAddress;
     this.shippingManagerId = shippingManagerId;
     this.shippingManagerSlackId = shippingManagerSlackId;
+  }
+  public void setEstimatedDeliveryData(long estimatedElapsedTime, double estimatedDistance){
+    this.estimatedElapsedTime = estimatedElapsedTime;
+    this.estimatedDistance = estimatedDistance;
+    this.shippingStartDate = LocalDateTime.now();
   }
 
   public void setDeliveryRoutes(List<DeliveryRoute> routes){

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/DeliveryRoute.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/DeliveryRoute.java
@@ -15,11 +15,13 @@ import java.time.Duration;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "P_DELIVERY_ROUTES")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class DeliveryRoute extends BaseEntity {
 
   @Id
@@ -40,8 +42,8 @@ public class DeliveryRoute extends BaseEntity {
   @Column(nullable = false)
   private UUID arrivalHubId;
 
-  private Integer expectedDistance;
-  private String expectedElapsedTime;
+  private double estimatedDistance;
+  private long estimatedElapsedTime;
 
   private Integer realDistance;
 
@@ -55,16 +57,16 @@ public class DeliveryRoute extends BaseEntity {
       int sequence,
       UUID departureHubId,
       UUID arrivalHubId,
-      Integer expectedDistance,
-      String expectedElapsedTime,
+      double estimatedDistance,
+      long estimatedElapsedTime,
       Integer realDistance,
       Duration realElapsedTime) {
     this.delivery = delivery;
     this.sequence = sequence;
     this.departureHubId = departureHubId;
     this.arrivalHubId = arrivalHubId;
-    this.expectedDistance = expectedDistance;
-    this.expectedElapsedTime = expectedElapsedTime;
+    this.estimatedDistance = estimatedDistance;
+    this.estimatedElapsedTime = estimatedElapsedTime;
     this.realDistance = realDistance;
     this.realElapsedTime = realElapsedTime;
   }

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/State.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/State.java
@@ -4,13 +4,10 @@ public class State {
 
   public enum DeliveryState {
     PENDING("배송대기"),
-    REQUESTED("배송요청"),
-    IN_TRANSIT_TO_HUB("허브이동중"),
-    AT_ARRIVAL_HUB("목적지허브도착"),
-    OUT_FOR_DELIVERY("출고완료"),
-    IN_TRANSIT_TO_COMPANY("업체배송중"),
-    DELIVERED("업체배송완료"),
-    CONFIRMED("업체배송확정");
+    REQUESTED("배송요청"),// 외부 API 전파없음
+    IN_TRANSIT("배송중"),
+    DELIVERED("배송완료"),
+    CONFIRMED("배송확정");
 
     final String description;
 
@@ -23,6 +20,7 @@ public class State {
     PENDING("허브이동대기중"),
     IN_TRANSIT_TO_HUB("허브이동중"),
     AT_ARRIVAL_HUB("목적지허브도착"),
+    OUT_FOR_DELIVERY("출고완료"),
     IN_TRANSIT_TO_COMPANY("업체배송중"),
     DELIVERED("배송완료");
     final String description;

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/client/HubClient.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/client/HubClient.java
@@ -1,0 +1,16 @@
+package com.sparta.delivery.infrastructure.client;
+
+import com.sparta.hub.dto.InterHubResponse;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+@FeignClient(name = "hub-service")
+public interface HubClient {
+  @GetMapping("/internal/interhubs")
+  Optional<InterHubResponse> getDeliveryRoutes(
+      @RequestParam("departureHubId") UUID departureHubId,
+      @RequestParam("arrivalHubId") UUID arrivalHubId
+  );
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/configuration/KafkaConfig.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/configuration/KafkaConfig.java
@@ -1,0 +1,23 @@
+package com.sparta.delivery.infrastructure.configuration;
+
+import com.sparta.delivery.application.DeliveryService;
+import com.sparta.delivery.dto.StateUpdateDto;
+import com.sparta.delivery.infrastructure.messaging.StateProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ConditionalOnProperty(value = "kafka.enabled", matchIfMissing = true)
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConfig {
+  private final KafkaTemplate<String, StateUpdateDto> kafkaTemplate;
+
+  @Bean
+  public StateProducer stateProducer(){
+    return new StateProducer(kafkaTemplate);
+  }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/messaging/StateProducer.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/messaging/StateProducer.java
@@ -1,0 +1,18 @@
+package com.sparta.delivery.infrastructure.messaging;
+
+import com.sparta.delivery.dto.StateUpdateDto;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@RequiredArgsConstructor
+@Slf4j(topic = "StateProducer from DeliveryServer")
+public class StateProducer {
+  private final KafkaTemplate<String, StateUpdateDto> kafkaTemplate;
+
+  public void send(String topic, UUID orderId, StateUpdateDto stateDto){
+    kafkaTemplate.send(topic, orderId.toString(), stateDto);
+    log.info("send to kafka finished");
+  }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRepository.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRepository.java
@@ -1,7 +1,10 @@
 package com.sparta.delivery.infrastructure.repository;
 
 import com.sparta.delivery.domain.model.Delivery;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {}
+public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
+  Optional<Delivery> findByDeliveryId(UUID deliveryId);
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRepository.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.infrastructure.repository;
+
+import com.sparta.delivery.domain.model.Delivery;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRouteRepository.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRouteRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.infrastructure.repository;
+
+import com.sparta.delivery.domain.model.DeliveryRoute;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryRouteRepository extends JpaRepository<DeliveryRoute, UUID> {}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/DeliveryController.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/DeliveryController.java
@@ -1,0 +1,26 @@
+package com.sparta.delivery.presentation;
+
+import com.sparta.commons.domain.response.ResponseBody;
+import com.sparta.commons.domain.response.SuccessResponseBody;
+import com.sparta.delivery.application.DeliveryFacadeService;
+import com.sparta.delivery.presentation.dto.DeliveryResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/deliveries")
+public class DeliveryController {
+  private final DeliveryFacadeService deliveryFacadeService;
+
+  @PostMapping("/{deliveryId}/requested")
+  public ResponseBody<DeliveryResponse> requestDeliveryAndCreateRoute(
+      @PathVariable("deliveryId") UUID deliveryId) {
+    return new SuccessResponseBody<>(
+        deliveryFacadeService.requestDeliveryAndCreateRoute(deliveryId));
+  }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/dto/DeliveryResponse.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/dto/DeliveryResponse.java
@@ -1,0 +1,80 @@
+package com.sparta.delivery.presentation.dto;
+
+import com.sparta.delivery.domain.model.Delivery;
+import com.sparta.delivery.domain.model.DeliveryRoute;
+import com.sparta.delivery.domain.model.State.DeliveryState;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DeliveryResponse {
+  private UUID deliveryId;
+  private UUID orderId;
+  private UUID departureHubId;
+  private UUID arrivalHubId;
+  private DeliveryState state;
+  private String shippingAddress;
+  private UUID shippingManagerId;
+  private String shippingManagerSlackId;
+  private List<DeliveryRouteResponse> routes;
+  private long estimatedElapsedTime;
+  private double estimatedDistance;
+  private LocalDateTime shippingStartDate;
+  private LocalDateTime shippingEndDate;
+  private boolean isDelete = false;
+
+  @Builder
+  private DeliveryResponse(UUID deliveryId, UUID orderId, UUID departureHubId, UUID arrivalHubId,
+      DeliveryState state, String shippingAddress, UUID shippingManagerId,
+      String shippingManagerSlackId, List<DeliveryRouteResponse> routes, long estimatedElapsedTime,
+      double estimatedDistance, LocalDateTime shippingStartDate, LocalDateTime shippingEndDate,
+      boolean isDelete) {
+    this.deliveryId = deliveryId;
+    this.orderId = orderId;
+    this.departureHubId = departureHubId;
+    this.arrivalHubId = arrivalHubId;
+    this.state = state;
+    this.shippingAddress = shippingAddress;
+    this.shippingManagerId = shippingManagerId;
+    this.shippingManagerSlackId = shippingManagerSlackId;
+    this.routes = routes;
+    this.estimatedElapsedTime = estimatedElapsedTime;
+    this.estimatedDistance = estimatedDistance;
+    this.shippingStartDate = shippingStartDate;
+    this.shippingEndDate = shippingEndDate;
+    this.isDelete = isDelete;
+  }
+
+  public static DeliveryResponse fromEntity(Delivery delivery){
+    return DeliveryResponse.builder()
+        .deliveryId(delivery.getDeliveryId())
+        .orderId(delivery.getOrderId())
+        .state(delivery.getDeliveryState())
+        .departureHubId(delivery.getDepartureHubId())
+        .arrivalHubId(delivery.getArrivalHubId())
+        .shippingAddress(delivery.getShippingAddress())
+        .shippingManagerId(delivery.getShippingManagerId())
+        .shippingManagerSlackId(delivery.getShippingManagerSlackId())
+        .routes(
+            delivery.getRoutes().stream()
+                .map(DeliveryRouteResponse::fromEntity)
+                .collect(Collectors.toList()))
+        .estimatedDistance(delivery.getEstimatedDistance())
+        .estimatedElapsedTime(delivery.getEstimatedElapsedTime())
+        .shippingStartDate(delivery.getShippingStartDate())
+        .shippingEndDate(delivery.getShippingEndDate())
+        .build();
+  }
+
+
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/dto/DeliveryRouteResponse.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/dto/DeliveryRouteResponse.java
@@ -1,0 +1,55 @@
+package com.sparta.delivery.presentation.dto;
+
+import com.sparta.delivery.domain.model.DeliveryRoute;
+import com.sparta.delivery.domain.model.State.RouteState;
+import java.time.Duration;
+import java.util.UUID;
+import lombok.Builder;
+
+public class DeliveryRouteResponse {
+  private UUID deliveryRouteId;
+  private int sequence;
+  private UUID departureHubId;
+  private UUID arrivalHubId;
+  private RouteState routeState;
+  private double estimatedDistance;
+  private long estimatedElapsedTime;
+  private Integer realDistance;
+  private Duration realElapsedTime;
+
+  @Builder
+  private DeliveryRouteResponse(
+      UUID deliveryRouteId,
+      int sequence,
+      UUID departureHubId,
+      UUID arrivalHubId,
+      double estimatedDistance,
+      long estimatedElapsedTime,
+      Integer realDistance,
+      Duration realElapsedTime,
+      RouteState routeState) {
+    this.deliveryRouteId = deliveryRouteId;
+    this.sequence = sequence;
+    this.departureHubId = departureHubId;
+    this.arrivalHubId = arrivalHubId;
+    this.estimatedDistance = estimatedDistance;
+    this.estimatedElapsedTime = estimatedElapsedTime;
+    this.realDistance = realDistance;
+    this.realElapsedTime = realElapsedTime;
+    this.routeState = routeState;
+  }
+
+  public static DeliveryRouteResponse fromEntity(DeliveryRoute route){
+    return DeliveryRouteResponse.builder()
+        .deliveryRouteId(route.getDeliveryRouteId())
+        .sequence(route.getSequence())
+        .departureHubId(route.getDepartureHubId())
+        .arrivalHubId(route.getArrivalHubId())
+        .routeState(route.getRouteState())
+        .estimatedDistance(route.getEstimatedDistance())
+        .estimatedElapsedTime(route.getEstimatedElapsedTime())
+        .realDistance(route.getRealDistance())
+        .realElapsedTime(route.getRealElapsedTime())
+        .build();
+  }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/exception/DeliveryErrorCode.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/exception/DeliveryErrorCode.java
@@ -1,0 +1,36 @@
+package com.sparta.delivery.presentation.exception;
+
+import com.sparta.commons.domain.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum DeliveryErrorCode implements ErrorCode {
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "common_error_001", "서버 내부 에러"),
+  NOT_FOUND_DELIVERY(HttpStatus.NOT_FOUND, "delivery_error_001", "배송정보를 찾을 수 없습니다");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+  @Override
+  public int getStatus() {
+    return 0;
+  }
+
+  public HttpStatus getHttpStatus() {
+    return status;
+  }
+
+  @Override
+  public String getCode() {
+    return null;
+  }
+
+  @Override
+  public String getMessage() {
+    return null;
+  }
+}

--- a/service/delivery/delivery_server/src/main/resources/application-local.yml
+++ b/service/delivery/delivery_server/src/main/resources/application-local.yml
@@ -12,10 +12,27 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  kafka:
+    bootstrap-servers: ${KAFKA_URL}
+    listener:
+      ack-mode: MANUAL
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonDeserializer
+    consumer:
+      group-id: delivery
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringSerializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: "*"
 eureka:
   client:
     service-url:
       defaultZone: ${EUREKA_URL}
 server:
-  port: 19096
+  port: 19097
 

--- a/service/hub/hub-service/src/main/java/com/sparta/hub/presentation/InterHubInternalController.java
+++ b/service/hub/hub-service/src/main/java/com/sparta/hub/presentation/InterHubInternalController.java
@@ -21,16 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class InterHubInternalController {
 
   private final InterHubService interHubService;
-  private final CompanyClient companyClient;
   private final HubService hubService;
 
   @GetMapping
   public Optional<InterHubResponse> getDeliveryRoutes(
-      @RequestParam("supplierCompanyId") UUID supplierCompanyId,
-      @RequestParam("receiverCompanyId") UUID receiverCompanyId
+      @RequestParam("departureHubId") UUID departureHubId,
+      @RequestParam("arrivalHubId") UUID arrivalHubId
   ){
-    UUID departureHubId = companyClient.findHubByCompanyId(supplierCompanyId);
-    UUID arrivalHubId = companyClient.findHubByCompanyId(receiverCompanyId);
     InterHubResponse interHubResponse = interHubService.findInterHubByDpHubAndAvHub(
         departureHubId, arrivalHubId);
     return Optional.ofNullable(interHubResponse);

--- a/service/order/docker-compose.yml
+++ b/service/order/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    platform: linux/amd64
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: wurstmeister/kafka:latest
+    platform: linux/amd64
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:29092,OUTSIDE://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      KAFKA_CLUSTERS_0_READONLY: "false"
+
+

--- a/service/order/order_server/build.gradle
+++ b/service/order/order_server/build.gradle
@@ -39,11 +39,13 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/service/order/order_server/src/main/java/com/sparta/order/domain/model/OrderState.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/domain/model/OrderState.java
@@ -4,7 +4,8 @@ public enum OrderState {
     CREATED("주문생성"),
     SHIPPED("배송중"),
     DELIVERED("배송완료"),
-    CANCELLED("주문취소");
+    CONFIRMED("주문확정"),// API order -> delivery state 전파
+    CANCELLED("주문취소");// API order -> OrderState 변경 및 삭제 진행
 
     final String description;
 

--- a/service/order/order_server/src/main/resources/application-local.yml
+++ b/service/order/order_server/src/main/resources/application-local.yml
@@ -12,6 +12,18 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  kafka:
+    bootstrap-servers: ${KAFKA_URL}
+    consumer:
+      group-id: logistics
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringSerializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: "*"
 eureka:
   client:
     service-url:


### PR DESCRIPTION
### 🌱 작업 사항 
배송요청(배송상태를 requested로 변경)하면서 배송루트를 생성하는 API (배송루트생성이기 때문에 POST로 진행)
-> 주문생성요청엔 주문, 주문상세, 배송(비동기로 생성 요청)이 진행되고 배송루트가 생성되는 시점은 공급업체담당자가 물류핑에 배송을 요청하는 시점에서 생성된다고 정의하여 다음과 같이 진행하였습니다. 

### ❓ 리뷰 포인트
- 처음 #22 이슈를 카프카로 상태변경하는 걸로 잡았어서 카프카 의존성 코드들이 포함되어있습니다
- HubInternalController API를 수정하였습니다. 주문에서 배송루트를 생성하는게 아니라 배송에서 생성되기때문에 companyId가 아닌 바로 Delivery에 있는 HubId로 InterHub 정보를 가져올 수 있게끔 변경하였습니다
- 테스트는 주문생성에서 Delivery 생성을 비동기로 요청하는 작업을 올리는 PR로 delivery를 생성 후 해당 PR에 상태변경 API 테스트까지 포함해서 올리겠습니다

### 🦄 관련 이슈
resolves #22 
