### PR TITLE
[#32] 업체 배송 담당자에게 slack 알림을 보내는 스케줄러 개발

### DIFF
--- a/service/notification/.gitignore
+++ b/service/notification/.gitignore
@@ -1,0 +1,37 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/

--- a/service/notification/build.gradle
+++ b/service/notification/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'com.slack.api:slack-api-client:1.27.2'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/service/notification/build.gradle
+++ b/service/notification/build.gradle
@@ -1,0 +1,53 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '3.3.3'
+	id 'io.spring.dependency-management' version '1.1.6'
+}
+
+group = 'com.sparta'
+version = '0.0.1-SNAPSHOT'
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+ext {
+	set('springCloudVersion', "2023.0.3")
+}
+
+dependencies {
+	implementation project(':common:domain')
+
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}

--- a/service/notification/docker-compose.yml
+++ b/service/notification/docker-compose.yml
@@ -1,0 +1,12 @@
+# for local development
+version: '3.7'
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: mongodb_boot
+    restart: always
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=testpassword1234

--- a/service/notification/src/main/java/com/sparta/notification/NotificationApplication.java
+++ b/service/notification/src/main/java/com/sparta/notification/NotificationApplication.java
@@ -3,7 +3,9 @@ package com.sparta.notification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class NotificationApplication {
 

--- a/service/notification/src/main/java/com/sparta/notification/NotificationApplication.java
+++ b/service/notification/src/main/java/com/sparta/notification/NotificationApplication.java
@@ -1,0 +1,14 @@
+package com.sparta.notification;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+public class NotificationApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(NotificationApplication.class, args);
+  }
+
+}

--- a/service/notification/src/main/java/com/sparta/notification/application/scheduler/CompanyDeliveryAgentSlackNotificationScheduler.java
+++ b/service/notification/src/main/java/com/sparta/notification/application/scheduler/CompanyDeliveryAgentSlackNotificationScheduler.java
@@ -48,7 +48,8 @@ public class CompanyDeliveryAgentSlackNotificationScheduler {
     List<Item> items = fetchWeatherData();
 
     // 2. 유저서버로 부터 허브 배송 담당자 id 목록 받아오기
-    List<UUID> hubDeliveryAgentIdList = userFeignClient.getHubDeliveryAgentIdList();
+    List<UUID> hubDeliveryAgentIdList = userFeignClient.getDeliveryAgentIdList("HUB_DELIVERY_AGENT");
+    log.info("hubDeliveryAgentIdList : {}", hubDeliveryAgentIdList);
 
     for (UUID hubDeliveryAgentId : hubDeliveryAgentIdList) {
       // 3. 배송 서버로부터 해당 배송 담당자 id 기반 배송 목록 받아오기

--- a/service/notification/src/main/java/com/sparta/notification/application/scheduler/CompanyDeliveryAgentSlackNotificationScheduler.java
+++ b/service/notification/src/main/java/com/sparta/notification/application/scheduler/CompanyDeliveryAgentSlackNotificationScheduler.java
@@ -1,0 +1,158 @@
+package com.sparta.notification.application.scheduler;
+
+import com.sparta.notification.application.utils.SlackNotificationSender;
+import com.sparta.notification.application.utils.WeatherSummary;
+import com.sparta.notification.infrastructure.configuration.properties.WeatherProperties;
+import com.sparta.notification.infrastructure.feign.ai.GeminiFeignClient;
+import com.sparta.notification.infrastructure.feign.ai.GenerateContentRequest;
+import com.sparta.notification.infrastructure.feign.ai.GenerateContentResponse;
+import com.sparta.notification.infrastructure.feign.delivery.DeliveryFeignClient;
+import com.sparta.notification.infrastructure.feign.user.UserFeignClient;
+import com.sparta.notification.infrastructure.feign.weather.WeatherFeignClient;
+import com.sparta.notification.infrastructure.feign.weather.WeatherResponse;
+import com.sparta.notification.infrastructure.feign.weather.WeatherResponse.Item;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@EnableConfigurationProperties(WeatherProperties.class)
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CompanyDeliveryAgentSlackNotificationScheduler {
+
+  public static final String SUMMARIZE_QUESTION_FROM = "현재 날씨는 %s이고, 배송 목록은 다음과 같습니다: %s. 이 두 가지를 종합하여 요약해 주세요.";
+
+  private final WeatherFeignClient weatherFeignClient;
+  private final WeatherProperties weatherProperties;
+  private final UserFeignClient userFeignClient;
+  private final DeliveryFeignClient deliveryFeignClient;
+  private final GeminiFeignClient geminiFeignClient;
+  private final SlackNotificationSender slackNotificationSender;
+
+
+  //  @Scheduled(cron = "*/10 * * * * ?") // test
+  @Scheduled(cron = "0 0 6 * * ?")
+  public void run() throws IOException {
+    // 1. 공공 데이터 포털의 날씨 API를 사용하여 해당일의 날씨 정보를 가져오기
+    List<Item> items = fetchWeatherData();
+
+    // 2. 유저서버로 부터 허브 배송 담당자 id 목록 받아오기
+    List<UUID> hubDeliveryAgentIdList = userFeignClient.getHubDeliveryAgentIdList();
+
+    for (UUID hubDeliveryAgentId : hubDeliveryAgentIdList) {
+      // 3. 배송 서버로부터 해당 배송 담당자 id 기반 배송 목록 받아오기
+      List<String> deliveryList = fetchDeliveryList(hubDeliveryAgentId);
+
+      // 4. 질문 작성해서 gemini api 로 요약 요청 보내기
+      String question = createSummaryQuestion(items, deliveryList);
+      String responseText = requestSummaryFromGemini(question);
+
+      // 5. 슬랙 알림 보내기
+      notifySlack(responseText);
+    }
+  }
+
+  private List<Item> fetchWeatherData() {
+    String serviceKey = weatherProperties.getServiceKey();
+    String baseDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    String baseTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH00"));
+    int nx = 55; // TODO: 위치 정보 동적 할당 필요??
+    int ny = 127;
+
+    List<Item> items = getWeatherData(serviceKey, baseDate, baseTime, nx, ny);
+    log.info("weatherData : {}", items);
+    return items;
+  }
+
+  private List<String> fetchDeliveryList(UUID hubDeliveryAgentId) {
+    return deliveryFeignClient.getDeliveryListByShippingManagerId(hubDeliveryAgentId, LocalDateTime.now());
+  }
+
+  private String createSummaryQuestion(List<Item> items, List<String> deliveryList) {
+    String weatherSummary = summarizeWeatherData(items);
+    String deliverySummary = ""; // TODO. deliveryList 로 부터 요약 정보 String 반환
+    return String.format(SUMMARIZE_QUESTION_FROM, weatherSummary, deliverySummary);
+  }
+
+  private String requestSummaryFromGemini(String question) {
+    GenerateContentResponse response = geminiFeignClient.generateContent(
+        GenerateContentRequest.createQuestion(question)
+    );
+    String responseText = response.getCandidates().get(0).getContent().getParts().get(0).getText();
+    log.info("text : {}", responseText);
+    return responseText;
+  }
+
+  private void notifySlack(String message) throws IOException {
+    slackNotificationSender.execute(message);
+  }
+
+  private List<Item> getWeatherData(String serviceKey, String baseDate, String baseTime, int nx,
+      int ny) {
+    WeatherResponse.items weatherData = weatherFeignClient.getWeatherData(
+        serviceKey,
+        1,
+        1000,
+        "JSON",
+        baseDate,
+        baseTime,
+        nx,
+        ny);
+
+    return weatherData.getItem();
+  }
+
+  private String summarizeWeatherData(List<Item> items) {
+    StringBuilder summary = new StringBuilder();
+    WeatherSummary weatherSummary = new WeatherSummary();
+
+    for (Item item : items) {
+      switch (item.getCategory()) {
+        case "T1H":
+          weatherSummary.setTemperature(item.getObsrValue() + "℃");
+          break;
+        case "REH":
+          weatherSummary.setHumidity(item.getObsrValue() + "%");
+          break;
+        case "RN1":
+          weatherSummary.setPrecipitation(item.getObsrValue() + "mm");
+          break;
+        case "WSD":
+          weatherSummary.setWindSpeed(item.getObsrValue() + "m/s");
+          break;
+        case "PTY":
+          weatherSummary.setPrecipitationType(getPrecipitationType(item.getObsrValue()));
+          break;
+        default:
+          break;
+      }
+    }
+
+    summary.append(weatherSummary);
+    return summary.toString();
+  }
+
+  private String getPrecipitationType(String obsrValue) {
+    int ptyValue = Integer.parseInt(obsrValue);
+    return switch (ptyValue) {
+      case 0 -> "없음";
+      case 1 -> "비";
+      case 2 -> "비/눈";
+      case 3 -> "눈";
+      case 5 -> "빗방울";
+      case 6 -> "빗방울눈날림";
+      case 7 -> "눈날림";
+      case 4 -> "소나기";
+      default -> "알 수 없음";
+    };
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/application/scheduler/HubDeliveryAgentSlackNotificationScheduler.java
+++ b/service/notification/src/main/java/com/sparta/notification/application/scheduler/HubDeliveryAgentSlackNotificationScheduler.java
@@ -1,0 +1,17 @@
+package com.sparta.notification.application.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HubDeliveryAgentSlackNotificationScheduler {
+
+  @Scheduled(cron = "0 0 8 * * ?")
+  public void run() {
+    // 허브별 주문을 받아오기
+    // 1. 허브 서버로 부터 모든 허브의 아이디를 받아오기
+    // 2. 주문 서버로 부터 허브아이디를 통해 허브별 주문을 받아오기
+    // 3. Gemini API 를 통해 요약하기
+    // 4. 슬랙 알림 전송
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/application/service/SlackNotificationProvider.java
+++ b/service/notification/src/main/java/com/sparta/notification/application/service/SlackNotificationProvider.java
@@ -1,0 +1,25 @@
+package com.sparta.notification.application.service;
+
+import com.slack.api.model.block.LayoutBlock;
+import com.sparta.notification.infrastructure.configuration.properties.SlackProperties;
+import com.sparta.notification.infrastructure.slack.SlackHelper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SlackNotificationProvider {
+
+  private final SlackHelper slackHelper;
+  private final SlackProperties slackProperties;
+
+  @Async
+  public void sendNotification(List<LayoutBlock> layoutBlocks) {
+    slackHelper.sendNotification(slackProperties.getChannel(), layoutBlocks);
+  }
+
+}

--- a/service/notification/src/main/java/com/sparta/notification/application/utils/SlackNotificationSender.java
+++ b/service/notification/src/main/java/com/sparta/notification/application/utils/SlackNotificationSender.java
@@ -1,0 +1,42 @@
+package com.sparta.notification.application.utils;
+
+import static com.slack.api.model.block.Blocks.divider;
+import static com.slack.api.model.block.Blocks.section;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+
+import com.slack.api.model.block.Blocks;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.MarkdownTextObject;
+import com.sparta.notification.application.service.SlackNotificationProvider;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SlackNotificationSender {
+
+  private final SlackNotificationProvider slackProvider;
+
+  public void execute(String message) throws IOException {
+    List<LayoutBlock> layoutBlocks = new ArrayList<>();
+    layoutBlocks.add(
+        Blocks.header(
+            headerBlockBuilder ->
+                headerBlockBuilder.text(plainText("🚚 오늘의 배송정보 요약입니다."))));
+    layoutBlocks.add(divider());
+
+    MarkdownTextObject errorUserIdMarkdown =
+        MarkdownTextObject.builder().text("* message :*\n" + message).build();
+    layoutBlocks.add(
+        section(
+            section ->
+                section.fields(List.of(errorUserIdMarkdown))));
+
+    slackProvider.sendNotification(layoutBlocks);
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/application/utils/WeatherSummary.java
+++ b/service/notification/src/main/java/com/sparta/notification/application/utils/WeatherSummary.java
@@ -1,0 +1,18 @@
+package com.sparta.notification.application.utils;
+
+import lombok.Setter;
+
+@Setter
+public class WeatherSummary {
+  private String temperature = "N/A";
+  private String humidity = "N/A";
+  private String precipitation = "N/A";
+  private String windSpeed = "N/A";
+  private String precipitationType = "없음";
+
+  @Override
+  public String toString() {
+    return String.format("현재 기온: %s, 습도: %s, 1시간 강수량: %s, 풍속: %s, 강수형태: %s입니다.",
+        temperature, humidity, precipitation, windSpeed, precipitationType);
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/domain/model/SlackNotification.java
+++ b/service/notification/src/main/java/com/sparta/notification/domain/model/SlackNotification.java
@@ -1,0 +1,40 @@
+package com.sparta.notification.domain.model;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Document(collection = "slack_notification")
+public class SlackNotification {
+
+  @Id
+  private String id;
+
+  private String slackId;
+
+  private String message;
+
+  private LocalDateTime sentAt;
+
+  @Builder(access = AccessLevel.PRIVATE)
+  public SlackNotification(String slackId, LocalDateTime sentAt, String message) {
+    this.slackId = slackId;
+    this.sentAt = sentAt;
+    this.message = message;
+  }
+
+  public static SlackNotification create(String slackId, String message, LocalDateTime sentAt) {
+    return SlackNotification.builder()
+        .slackId(slackId)
+        .message(message)
+        .sentAt(sentAt)
+        .build();
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/domain/repository/SlackNotificationImpl.java
+++ b/service/notification/src/main/java/com/sparta/notification/domain/repository/SlackNotificationImpl.java
@@ -1,0 +1,18 @@
+package com.sparta.notification.domain.repository;
+
+import com.sparta.notification.domain.model.SlackNotification;
+import com.sparta.notification.infrastructure.repository.SlackNotificationMongoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class SlackNotificationImpl implements SlackNotificationRepository{
+
+  private final SlackNotificationMongoRepository slackNotificationMongoRepository;
+
+  @Override
+  public void save(SlackNotification slackNotification) {
+    slackNotificationMongoRepository.save(slackNotification);
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/domain/repository/SlackNotificationRepository.java
+++ b/service/notification/src/main/java/com/sparta/notification/domain/repository/SlackNotificationRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.notification.domain.repository;
+
+import com.sparta.notification.domain.model.SlackNotification;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SlackNotificationRepository {
+
+  void save(SlackNotification slackNotification);
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/SchedulerConfig.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package com.sparta.notification.infrastructure.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulerConfig {
+
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/SlackConfig.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/SlackConfig.java
@@ -1,0 +1,23 @@
+package com.sparta.notification.infrastructure.configuration;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.sparta.notification.infrastructure.configuration.properties.SlackProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@EnableConfigurationProperties(SlackProperties.class)
+@Configuration
+public class SlackConfig {
+
+  private final SlackProperties slackProperties;
+
+  @Bean
+  public MethodsClient getClient() {
+    Slack slackClient = Slack.getInstance();
+    return slackClient.methods(slackProperties.getToken());
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/TaskSchedulerConfig.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/TaskSchedulerConfig.java
@@ -1,0 +1,19 @@
+package com.sparta.notification.infrastructure.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class TaskSchedulerConfig implements SchedulingConfigurer {
+
+  @Override
+  public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+    ThreadPoolTaskScheduler threadPool = new ThreadPoolTaskScheduler();
+    int n = Runtime.getRuntime().availableProcessors(); // core 갯수
+    threadPool.setPoolSize(n * 2); // 쓰레드 풀 갯수 설정
+    threadPool.initialize();
+    taskRegistrar.setTaskScheduler(threadPool);
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/properties/GeminiProperties.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/properties/GeminiProperties.java
@@ -1,0 +1,12 @@
+package com.sparta.notification.infrastructure.configuration.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "gemini")
+public class GeminiProperties {
+  private String apiKey;
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/properties/SlackProperties.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/properties/SlackProperties.java
@@ -1,0 +1,13 @@
+package com.sparta.notification.infrastructure.configuration.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "slack")
+public class SlackProperties {
+  private String token;
+  private String channel;
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/properties/WeatherProperties.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/configuration/properties/WeatherProperties.java
@@ -1,0 +1,12 @@
+package com.sparta.notification.infrastructure.configuration.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "weather")
+public class WeatherProperties {
+  private String serviceKey;
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/ai/GeminiFeignClient.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/ai/GeminiFeignClient.java
@@ -1,0 +1,15 @@
+package com.sparta.notification.infrastructure.feign.ai;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+    name = "geminiFeignClient",
+    url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+    configuration = GeminiFeignConfig.class)
+public interface GeminiFeignClient {
+
+  @PostMapping
+  GenerateContentResponse generateContent(@RequestBody GenerateContentRequest request);
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/ai/GeminiFeignConfig.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/ai/GeminiFeignConfig.java
@@ -1,0 +1,23 @@
+package com.sparta.notification.infrastructure.feign.ai;
+
+import com.sparta.notification.infrastructure.configuration.properties.GeminiProperties;
+import feign.RequestInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+@RequiredArgsConstructor
+@EnableConfigurationProperties(GeminiProperties.class)
+public class GeminiFeignConfig {
+
+  private final GeminiProperties geminiProperties;
+
+  @Bean
+  public RequestInterceptor requestInterceptor() {
+    return requestTemplate -> {
+      requestTemplate.header("Content-Type", "application/json; charset=utf-8");
+      requestTemplate.header("x-goog-api-key", geminiProperties.getApiKey());
+    };
+  }
+
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/ai/GenerateContentRequest.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/ai/GenerateContentRequest.java
@@ -1,0 +1,39 @@
+package com.sparta.notification.infrastructure.feign.ai;
+
+import com.sparta.notification.infrastructure.feign.ai.GenerateContentRequest.Content.Part;
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenerateContentRequest {
+  private List<Content> contents;
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Content {
+    private List<Part> parts;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Part {
+      private String text;
+    }
+  }
+
+  public static GenerateContentRequest createQuestion(String text) {
+    Part part = new Part(text);
+    Content content = new Content(Collections.singletonList(part));
+    return new GenerateContentRequest(Collections.singletonList(content));
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/ai/GenerateContentResponse.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/ai/GenerateContentResponse.java
@@ -1,0 +1,50 @@
+package com.sparta.notification.infrastructure.feign.ai;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Setter
+@NoArgsConstructor
+public class GenerateContentResponse {
+  private List<Candidate> candidates;
+
+  @ToString
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  public static class Candidate {
+    private Content content;
+    private String finishReason;
+    private int index;
+    private List<SafetyRating> safetyRatings;
+
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Content {
+      private List<Part> parts;
+
+      @ToString
+      @Getter
+      @Setter
+      @NoArgsConstructor
+      public static class Part {
+        private String text;
+      }
+    }
+  }
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  public static class SafetyRating {
+    private String category;
+    private String probability;
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/delivery/DeliveryFeignClient.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/delivery/DeliveryFeignClient.java
@@ -1,0 +1,17 @@
+package com.sparta.notification.infrastructure.feign.delivery;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "delivery")
+public interface DeliveryFeignClient {
+
+  // TODO. 반환 값 추후 수정
+  @GetMapping("/internal/deliveries")
+  List<String> getDeliveryListByShippingManagerId(@RequestParam UUID shippingManagerId,
+      @RequestParam LocalDateTime shippingStartDate);
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/user/UserFeignClient.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/user/UserFeignClient.java
@@ -1,0 +1,13 @@
+package com.sparta.notification.infrastructure.feign.user;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "user-service")
+public interface UserFeignClient {
+
+  @GetMapping("/internal/users/hubDeliveryAgents")
+  List<UUID> getHubDeliveryAgentIdList();
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/user/UserFeignClient.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/user/UserFeignClient.java
@@ -4,10 +4,11 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "user-service")
 public interface UserFeignClient {
 
-  @GetMapping("/internal/users/hubDeliveryAgents")
-  List<UUID> getHubDeliveryAgentIdList();
+  @GetMapping("/internal/shippingManagers/deliveryAgents")
+  List<UUID> getDeliveryAgentIdList(@RequestParam String shippingManagerType);
 }

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherDeserializer.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherDeserializer.java
@@ -1,0 +1,36 @@
+package com.sparta.notification.infrastructure.feign.weather;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class WeatherDeserializer {
+
+  private final ObjectMapper objectMapper;
+
+  public WeatherResponse.items deserialize(JsonNode node) throws IOException {
+    JsonNode responseNode = node.findValue("response");
+
+    JsonNode itemNode = responseNode.get("body").get("items").get("item");
+    WeatherResponse.Item[] items = objectMapper.treeToValue(itemNode, WeatherResponse.Item[].class);
+
+    // 필요한 카테고리만 필터링
+    List<WeatherResponse.Item> filteredItems = new ArrayList<>();
+    for (WeatherResponse.Item item : items) {
+      String category = item.getCategory();
+      if (category.equals("T1H") || category.equals("RN1") ||
+          category.equals("REH") || category.equals("PTY") ||
+          category.equals("WSD")) {
+        filteredItems.add(item);
+      }
+    }
+
+    return new WeatherResponse.items(filteredItems);
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherFeignClient.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherFeignClient.java
@@ -1,0 +1,21 @@
+package com.sparta.notification.infrastructure.feign.weather;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "weatherClient", url = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0", configuration = WeatherFeignConfig.class)
+public interface WeatherFeignClient {
+
+  @GetMapping("/getUltraSrtNcst")
+  WeatherResponse.items getWeatherData(
+      @RequestParam("serviceKey") String serviceKey,
+      @RequestParam("pageNo") int pageNo,
+      @RequestParam("numOfRows") int numOfRows,
+      @RequestParam("dataType") String dataType,
+      @RequestParam("base_date") String baseDate,
+      @RequestParam("base_time") String baseTime,
+      @RequestParam("nx") int nx,
+      @RequestParam("ny") int ny
+  );
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherFeignConfig.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherFeignConfig.java
@@ -1,0 +1,15 @@
+package com.sparta.notification.infrastructure.feign.weather;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.codec.Decoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WeatherFeignConfig {
+
+  @Bean
+  public Decoder decoder(ObjectMapper objectMapper) {
+    return new WeatherFeignDecoder(objectMapper);
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherFeignDecoder.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherFeignDecoder.java
@@ -1,0 +1,30 @@
+package com.sparta.notification.infrastructure.feign.weather;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import feign.Response;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class WeatherFeignDecoder implements Decoder {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public Object decode(Response response, Type type)
+      throws IOException, DecodeException, FeignException {
+    if (type == WeatherResponse.items.class) {
+      JsonNode jsonNode = objectMapper.readTree(response.body().asInputStream());
+      WeatherDeserializer deserializer = new WeatherDeserializer(objectMapper);
+      return deserializer.deserialize(jsonNode);
+    }
+    return objectMapper.readValue(response.body().asInputStream(), objectMapper.constructType(type));
+  }
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherResponse.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/feign/weather/WeatherResponse.java
@@ -1,0 +1,32 @@
+package com.sparta.notification.infrastructure.feign.weather;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+public class WeatherResponse {
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class items {
+    private List<Item> item;
+  }
+
+  @ToString
+  @Getter
+  @NoArgsConstructor
+  public static class Item{
+    private String baseDate;
+    private String baseTime;
+    private String category;
+    private Long nx;
+    private Long ny;
+    private String obsrValue;
+  }
+
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/repository/SlackNotificationMongoRepository.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/repository/SlackNotificationMongoRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.notification.infrastructure.repository;
+
+import com.sparta.notification.domain.model.SlackNotification;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SlackNotificationMongoRepository extends MongoRepository<SlackNotification, String> {
+
+}

--- a/service/notification/src/main/java/com/sparta/notification/infrastructure/slack/SlackHelper.java
+++ b/service/notification/src/main/java/com/sparta/notification/infrastructure/slack/SlackHelper.java
@@ -1,0 +1,33 @@
+package com.sparta.notification.infrastructure.slack;
+
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.model.block.LayoutBlock;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class SlackHelper {
+
+  private final MethodsClient methodsClient;
+
+  public void sendNotification(String CHANNEL_ID, List<LayoutBlock> layoutBlocks) {
+    ChatPostMessageRequest chatPostMessageRequest =
+        ChatPostMessageRequest.builder()
+            .channel(CHANNEL_ID)
+            .text("test")
+            .blocks(layoutBlocks)
+            .build();
+    try {
+      methodsClient.chatPostMessage(chatPostMessageRequest);
+    } catch (SlackApiException | IOException slackApiException) {
+      log.error(slackApiException.toString());
+    }
+  }
+}

--- a/service/notification/src/main/resources/application.yml
+++ b/service/notification/src/main/resources/application.yml
@@ -1,0 +1,26 @@
+server:
+  port: 19098
+
+spring:
+  application:
+    name: notification-service
+
+  data:
+    mongodb:
+      host: localhost
+      port: 27017
+      authentication-database: admin
+      username: root
+      password: testpassword1234
+
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/

--- a/service/notification/src/test/java/com/sparta/notification/NotificationApplicationTests.java
+++ b/service/notification/src/test/java/com/sparta/notification/NotificationApplicationTests.java
@@ -1,0 +1,13 @@
+package com.sparta.notification;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class NotificationApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/service/user/user_server/src/main/java/com/sparta/user/application/service/shipping_manager/ShippingManagerInternalService.java
+++ b/service/user/user_server/src/main/java/com/sparta/user/application/service/shipping_manager/ShippingManagerInternalService.java
@@ -1,0 +1,20 @@
+package com.sparta.user.application.service.shipping_manager;
+
+import com.sparta.user.domain.model.ShippingManager;
+import com.sparta.user.domain.model.vo.ShippingManagerType;
+import com.sparta.user.domain.repository.shipping_manager.ShippingManagerRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ShippingManagerInternalService {
+
+  private final ShippingManagerRepository shippingManagerRepository;
+
+  public List<UUID> getDeliveryAgentIdList(ShippingManagerType shippingManagerType) {
+    return shippingManagerRepository.findIdsByType(shippingManagerType);
+  }
+}

--- a/service/user/user_server/src/main/java/com/sparta/user/domain/repository/shipping_manager/ShippingManagerRepository.java
+++ b/service/user/user_server/src/main/java/com/sparta/user/domain/repository/shipping_manager/ShippingManagerRepository.java
@@ -2,6 +2,8 @@ package com.sparta.user.domain.repository.shipping_manager;
 
 import com.sparta.user.application.dto.SippingManagerInfo;
 import com.sparta.user.domain.model.ShippingManager;
+import com.sparta.user.domain.model.vo.ShippingManagerType;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -16,4 +18,6 @@ public interface ShippingManagerRepository {
   Page<SippingManagerInfo> findShippingManagerInfos(UUID shippingManagerId, String keyword, Pageable pageable);
 
   boolean existsBySlackId(String slackId);
+
+  List<UUID> findIdsByType(ShippingManagerType shippingManagerType);
 }

--- a/service/user/user_server/src/main/java/com/sparta/user/domain/repository/shipping_manager/ShippingManagerRepositoryImpl.java
+++ b/service/user/user_server/src/main/java/com/sparta/user/domain/repository/shipping_manager/ShippingManagerRepositoryImpl.java
@@ -2,8 +2,10 @@ package com.sparta.user.domain.repository.shipping_manager;
 
 import com.sparta.user.application.dto.SippingManagerInfo;
 import com.sparta.user.domain.model.ShippingManager;
+import com.sparta.user.domain.model.vo.ShippingManagerType;
 import com.sparta.user.infrastructure.repository.shipping_manager.ShippingManagerJpaRepository;
 import com.sparta.user.infrastructure.repository.shipping_manager.ShippingManagerQueryDSLRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +34,10 @@ public class ShippingManagerRepositoryImpl implements ShippingManagerRepository 
   @Override
   public boolean existsBySlackId(String slackId) {
     return shippingManagerJpaRepository.existsBySlackId(slackId);
+  }
+
+  @Override
+  public List<UUID> findIdsByType(ShippingManagerType shippingManagerType) {
+    return shippingManagerJpaRepository.findIdsByType(shippingManagerType);
   }
 }

--- a/service/user/user_server/src/main/java/com/sparta/user/infrastructure/repository/shipping_manager/ShippingManagerJpaRepository.java
+++ b/service/user/user_server/src/main/java/com/sparta/user/infrastructure/repository/shipping_manager/ShippingManagerJpaRepository.java
@@ -1,10 +1,16 @@
 package com.sparta.user.infrastructure.repository.shipping_manager;
 
 import com.sparta.user.domain.model.ShippingManager;
+import com.sparta.user.domain.model.vo.ShippingManagerType;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ShippingManagerJpaRepository extends JpaRepository<ShippingManager, UUID> {
 
   boolean existsBySlackId(String slackId);
+
+  @Query("SELECT sm.id FROM ShippingManager sm WHERE sm.type = :shippingManagerType")
+  List<UUID> findIdsByType(ShippingManagerType shippingManagerType);
 }

--- a/service/user/user_server/src/main/java/com/sparta/user/presentation/controller/shipping_manager/ShippingManagerInternalController.java
+++ b/service/user/user_server/src/main/java/com/sparta/user/presentation/controller/shipping_manager/ShippingManagerInternalController.java
@@ -1,0 +1,24 @@
+package com.sparta.user.presentation.controller.shipping_manager;
+
+import com.sparta.user.application.service.shipping_manager.ShippingManagerInternalService;
+import com.sparta.user.domain.model.vo.ShippingManagerType;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/internal/shipping-managers")
+public class ShippingManagerInternalController {
+
+  private final ShippingManagerInternalService shippingManagerInternalService;
+
+  @GetMapping("/deliveryAgents")
+  List<UUID> getDeliveryAgentIdList(@RequestParam ShippingManagerType shippingManagerType) {
+    return shippingManagerInternalService.getDeliveryAgentIdList(shippingManagerType);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,4 +25,6 @@ include(':service:order:order_dto')
 include(':service:delivery:delivery_server')
 include(':service:delivery:delivery_dto')
 
+include(':service:notification')
+
 include(':common:domain')


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 알림서버를 다 개발하려는 의미로 이슈를 팠는데, 리뷰할 내용이 많아질까봐 잘라서 올립니당.
- 추가 PR을 더 올리고 이슈를 닫으려 합니다.
- 작업사항으로는
  - 공공데이터 포탈에서 기상청 초단기실황 api 조회 구현
  - gemini api 연동
  - slack 알림 연동
  - mongodb 저장 구현
    - mongodb를 선택한 이유는 수정/삭제가 거의 없는 로그성 데이터이기 때문에 nosql 기반의 데이터베이스 중 가장 많이 사용해본 db라 선택했습니다.
### ❓ 리뷰 포인트
- 커밋별로 확인하시면 쉽게 리뷰하실 수 있습니당.
- delivery 서비스와의 연동은 아직 확인하지 못했고, delivery internal api 개발 후, 연동 확인할 예정입니다.
- slack 알림은 내배캠 slack에선 제약사항이 존재해 로컬에서 진행했습니다.
<img width="625" alt="image" src="https://github.com/user-attachments/assets/cf72cb61-c0cf-4f4b-8e13-f38a02384403">
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/d4f71b85-2108-4889-a5f8-aeb5c4aa4788">



### 🦄 관련 이슈
resolves #추가 PR후, 닫음 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
