### PR TITLE
[#40] 주문/배송 내부 API 구현 

### DIFF
--- a/service/delivery/delivery_dto/src/main/java/com/sparta/delivery/dto/DeliveryRouteDto.java
+++ b/service/delivery/delivery_dto/src/main/java/com/sparta/delivery/dto/DeliveryRouteDto.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.dto;
 
 import java.time.Duration;
 import java.util.UUID;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,20 +15,25 @@ public class DeliveryRouteDto {
   private UUID arrivalHubId;
   private double estimatedDistance;
   private long estimatedElapsedTime;
-  private Integer realDistance;
   private Duration realElapsedTime;
   private String routeState;
 
-  public DeliveryRouteDto(UUID deliveryRouteId, int sequence, UUID departureHubId,
-      UUID arrivalHubId, double estimatedDistance, long estimatedElapsedTime, Integer realDistance,
-      Duration realElapsedTime, String routeState) {
+  @Builder
+  public DeliveryRouteDto(
+      UUID deliveryRouteId,
+      int sequence,
+      UUID departureHubId,
+      UUID arrivalHubId,
+      double estimatedDistance,
+      long estimatedElapsedTime,
+      Duration realElapsedTime,
+      String routeState) {
     this.deliveryRouteId = deliveryRouteId;
     this.sequence = sequence;
     this.departureHubId = departureHubId;
     this.arrivalHubId = arrivalHubId;
     this.estimatedDistance = estimatedDistance;
     this.estimatedElapsedTime = estimatedElapsedTime;
-    this.realDistance = realDistance;
     this.realElapsedTime = realElapsedTime;
     this.routeState = routeState;
   }

--- a/service/delivery/delivery_server/build.gradle
+++ b/service/delivery/delivery_server/build.gradle
@@ -32,10 +32,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     //implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
@@ -52,4 +58,17 @@ dependencyManagement {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+//QueryDSL
+def generated = 'src/main/generated'
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+clean {
+    delete file(generated)
 }

--- a/service/delivery/delivery_server/src/main/generated/com/sparta/delivery/domain/model/QDelivery.java
+++ b/service/delivery/delivery_server/src/main/generated/com/sparta/delivery/domain/model/QDelivery.java
@@ -1,0 +1,84 @@
+package com.sparta.delivery.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QDelivery is a Querydsl query type for Delivery
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QDelivery extends EntityPathBase<Delivery> {
+
+    private static final long serialVersionUID = 1807979663L;
+
+    public static final QDelivery delivery = new QDelivery("delivery");
+
+    public final com.sparta.commons.domain.jpa.QBaseEntity _super = new com.sparta.commons.domain.jpa.QBaseEntity(this);
+
+    public final ComparablePath<java.util.UUID> arrivalHubId = createComparable("arrivalHubId", java.util.UUID.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final StringPath createdBy = _super.createdBy;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    //inherited
+    public final StringPath deletedBy = _super.deletedBy;
+
+    public final ComparablePath<java.util.UUID> deliveryId = createComparable("deliveryId", java.util.UUID.class);
+
+    public final EnumPath<State.DeliveryState> deliveryState = createEnum("deliveryState", State.DeliveryState.class);
+
+    public final ComparablePath<java.util.UUID> departureHubId = createComparable("departureHubId", java.util.UUID.class);
+
+    public final NumberPath<Double> estimatedDistance = createNumber("estimatedDistance", Double.class);
+
+    public final NumberPath<Long> estimatedElapsedTime = createNumber("estimatedElapsedTime", Long.class);
+
+    public final BooleanPath isDelete = createBoolean("isDelete");
+
+    public final ComparablePath<java.util.UUID> orderId = createComparable("orderId", java.util.UUID.class);
+
+    public final ListPath<DeliveryRoute, QDeliveryRoute> routes = this.<DeliveryRoute, QDeliveryRoute>createList("routes", DeliveryRoute.class, QDeliveryRoute.class, PathInits.DIRECT2);
+
+    public final StringPath shippingAddress = createString("shippingAddress");
+
+    public final DateTimePath<java.time.LocalDateTime> shippingEndDate = createDateTime("shippingEndDate", java.time.LocalDateTime.class);
+
+    public final ComparablePath<java.util.UUID> shippingManagerId = createComparable("shippingManagerId", java.util.UUID.class);
+
+    public final StringPath shippingManagerSlackId = createString("shippingManagerSlackId");
+
+    public final DateTimePath<java.time.LocalDateTime> shippingStartDate = createDateTime("shippingStartDate", java.time.LocalDateTime.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    //inherited
+    public final StringPath updatedBy = _super.updatedBy;
+
+    public QDelivery(String variable) {
+        super(Delivery.class, forVariable(variable));
+    }
+
+    public QDelivery(Path<? extends Delivery> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QDelivery(PathMetadata metadata) {
+        super(Delivery.class, metadata);
+    }
+
+}
+

--- a/service/delivery/delivery_server/src/main/generated/com/sparta/delivery/domain/model/QDeliveryRoute.java
+++ b/service/delivery/delivery_server/src/main/generated/com/sparta/delivery/domain/model/QDeliveryRoute.java
@@ -1,0 +1,87 @@
+package com.sparta.delivery.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QDeliveryRoute is a Querydsl query type for DeliveryRoute
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QDeliveryRoute extends EntityPathBase<DeliveryRoute> {
+
+    private static final long serialVersionUID = -65687814L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QDeliveryRoute deliveryRoute = new QDeliveryRoute("deliveryRoute");
+
+    public final com.sparta.commons.domain.jpa.QBaseEntity _super = new com.sparta.commons.domain.jpa.QBaseEntity(this);
+
+    public final ComparablePath<java.util.UUID> arrivalHubId = createComparable("arrivalHubId", java.util.UUID.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final StringPath createdBy = _super.createdBy;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    //inherited
+    public final StringPath deletedBy = _super.deletedBy;
+
+    public final QDelivery delivery;
+
+    public final ComparablePath<java.util.UUID> deliveryRouteId = createComparable("deliveryRouteId", java.util.UUID.class);
+
+    public final ComparablePath<java.util.UUID> departureHubId = createComparable("departureHubId", java.util.UUID.class);
+
+    public final NumberPath<Double> estimatedDistance = createNumber("estimatedDistance", Double.class);
+
+    public final NumberPath<Long> estimatedElapsedTime = createNumber("estimatedElapsedTime", Long.class);
+
+    public final NumberPath<Integer> realDistance = createNumber("realDistance", Integer.class);
+
+    public final ComparablePath<java.time.Duration> realElapsedTime = createComparable("realElapsedTime", java.time.Duration.class);
+
+    public final EnumPath<State.RouteState> routeState = createEnum("routeState", State.RouteState.class);
+
+    public final NumberPath<Integer> sequence = createNumber("sequence", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    //inherited
+    public final StringPath updatedBy = _super.updatedBy;
+
+    public QDeliveryRoute(String variable) {
+        this(DeliveryRoute.class, forVariable(variable), INITS);
+    }
+
+    public QDeliveryRoute(Path<? extends DeliveryRoute> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QDeliveryRoute(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QDeliveryRoute(PathMetadata metadata, PathInits inits) {
+        this(DeliveryRoute.class, metadata, inits);
+    }
+
+    public QDeliveryRoute(Class<? extends DeliveryRoute> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.delivery = inits.isInitialized("delivery") ? new QDelivery(forProperty("delivery")) : null;
+    }
+
+}
+

--- a/service/delivery/delivery_server/src/main/generated/com/sparta/delivery/domain/model/QDeliveryRoute.java
+++ b/service/delivery/delivery_server/src/main/generated/com/sparta/delivery/domain/model/QDeliveryRoute.java
@@ -48,8 +48,6 @@ public class QDeliveryRoute extends EntityPathBase<DeliveryRoute> {
 
     public final NumberPath<Long> estimatedElapsedTime = createNumber("estimatedElapsedTime", Long.class);
 
-    public final NumberPath<Integer> realDistance = createNumber("realDistance", Integer.class);
-
     public final ComparablePath<java.time.Duration> realElapsedTime = createComparable("realElapsedTime", java.time.Duration.class);
 
     public final EnumPath<State.RouteState> routeState = createEnum("routeState", State.RouteState.class);

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryFacadeService.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryFacadeService.java
@@ -3,12 +3,16 @@ package com.sparta.delivery.application;
 import com.sparta.commons.domain.exception.BusinessException;
 import com.sparta.delivery.domain.model.Delivery;
 import com.sparta.delivery.dto.DeliveryCreateDto;
+import com.sparta.delivery.dto.DeliveryDto;
 import com.sparta.delivery.infrastructure.client.CompanyClient;
 import com.sparta.delivery.infrastructure.client.HubClient;
 import com.sparta.delivery.presentation.dto.DeliveryResponse;
 import com.sparta.delivery.presentation.exception.DeliveryErrorCode;
 import com.sparta.hub.dto.InterHubResponse;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -42,7 +46,16 @@ public class DeliveryFacadeService {
     return DeliveryResponse.fromEntity(delivery);
   }
 
-  private UUID getHubId(UUID companyId){
+  public List<DeliveryDto> findDeliveriesByShippingManagerId(
+      UUID shippingManagerId, LocalDateTime requestedDateTime) {
+    return deliveryService
+        .getDeliveriesByShippingManager(shippingManagerId, requestedDateTime)
+        .stream()
+        .map(DeliveryMapper::toDeliveryDto)
+        .collect(Collectors.toList());
+  }
+
+  private UUID getHubId(UUID companyId) {
     return companyClient
         .getHubIdByCompanyId(companyId)
         .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_HUB));

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryMapper.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryMapper.java
@@ -1,0 +1,42 @@
+package com.sparta.delivery.application;
+
+import com.sparta.delivery.domain.model.Delivery;
+import com.sparta.delivery.domain.model.DeliveryRoute;
+import com.sparta.delivery.dto.DeliveryDto;
+import com.sparta.delivery.dto.DeliveryRouteDto;
+import java.util.stream.Collectors;
+
+public class DeliveryMapper {
+  public static DeliveryDto toDeliveryDto(Delivery delivery){
+    return DeliveryDto.builder()
+        .deliveryId(delivery.getDeliveryId())
+        .departureHubId(delivery.getDepartureHubId())
+        .arrivalHubId(delivery.getArrivalHubId())
+        .deliveryState(delivery.getDeliveryState().name())
+        .shippingManagerId(delivery.getShippingManagerId())
+        .shippingManagerSlackId(delivery.getShippingManagerSlackId())
+        .shippingAddress(delivery.getShippingAddress())
+        .shippingStartDate(delivery.getShippingStartDate())
+        .shippingEndDate(delivery.getShippingEndDate())
+        .estimatedDistance(delivery.getEstimatedDistance())
+        .estimatedElapsedTime(delivery.getEstimatedElapsedTime())
+        .routes(delivery.getRoutes().stream()
+            .map(DeliveryMapper::toDeliveryRouteDto)
+            .collect(Collectors.toList()))
+        .build();
+  }
+
+  public static DeliveryRouteDto toDeliveryRouteDto(DeliveryRoute deliveryRoute){
+    return DeliveryRouteDto.builder()
+        .deliveryRouteId(deliveryRoute.getDeliveryRouteId())
+        .sequence(deliveryRoute.getSequence())
+        .departureHubId(deliveryRoute.getDepartureHubId())
+        .arrivalHubId(deliveryRoute.getArrivalHubId())
+        .routeState(deliveryRoute.getRouteState().name())
+        .estimatedDistance(deliveryRoute.getEstimatedDistance())
+        .estimatedElapsedTime(deliveryRoute.getEstimatedElapsedTime())
+        .realElapsedTime(deliveryRoute.getRealElapsedTime())
+        .build();
+  }
+
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryService.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/application/DeliveryService.java
@@ -5,7 +5,10 @@ import com.sparta.delivery.domain.model.Delivery;
 import com.sparta.delivery.domain.model.State.DeliveryState;
 import com.sparta.delivery.dto.DeliveryCreateDto;
 import com.sparta.delivery.infrastructure.repository.DeliveryRepository;
+import com.sparta.delivery.infrastructure.repository.DeliveryRepositoryImpl;
 import com.sparta.delivery.presentation.exception.DeliveryErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeliveryService {
   private final DeliveryRepository deliveryRepository;
+  private final DeliveryRepositoryImpl deliveryQueryRepository;
 
   public void createDelivery(
       UUID departureHubId, UUID arrivalHubId, DeliveryCreateDto request, UUID orderId) {
@@ -46,5 +50,10 @@ public class DeliveryService {
             .findByOrderId(orderId)
             .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY));
     deliveryRepository.delete(delivery);
+  }
+
+  public List<Delivery> getDeliveriesByShippingManager(
+      UUID shippingManagerId, LocalDateTime shippingStartDate) {
+    return deliveryQueryRepository.findDeliveries(shippingManagerId, shippingStartDate);
   }
 }

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/Delivery.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/Delivery.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
@@ -27,7 +28,10 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
-@Table(name = "P_DELIVERIES")
+@Table(name = "P_DELIVERIES",
+    indexes = {
+        @Index(name = "idx_shipping_manager_id", columnList = "shipping_manager_id")
+    })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_delete is false")
 @SQLDelete(sql = "UPDATE p_deliveries SET deleted_at = NOW() where delivery_id = ?")

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/DeliveryRoute.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/domain/model/DeliveryRoute.java
@@ -45,8 +45,6 @@ public class DeliveryRoute extends BaseEntity {
   private double estimatedDistance;
   private long estimatedElapsedTime;
 
-  private Integer realDistance;
-
   private Duration realElapsedTime;
 
   private RouteState routeState = RouteState.PENDING;
@@ -59,7 +57,6 @@ public class DeliveryRoute extends BaseEntity {
       UUID arrivalHubId,
       double estimatedDistance,
       long estimatedElapsedTime,
-      Integer realDistance,
       Duration realElapsedTime) {
     this.delivery = delivery;
     this.sequence = sequence;
@@ -67,7 +64,6 @@ public class DeliveryRoute extends BaseEntity {
     this.arrivalHubId = arrivalHubId;
     this.estimatedDistance = estimatedDistance;
     this.estimatedElapsedTime = estimatedElapsedTime;
-    this.realDistance = realDistance;
     this.realElapsedTime = realElapsedTime;
   }
 

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/configuration/JpaConfig.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/configuration/JpaConfig.java
@@ -1,0 +1,17 @@
+package com.sparta.delivery.infrastructure.configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+  @PersistenceContext private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRepositoryCustom.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.infrastructure.repository;
+
+import com.sparta.delivery.domain.model.Delivery;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface DeliveryRepositoryCustom {
+  List<Delivery> findDeliveries(UUID shippingManagerId, LocalDateTime requestedDateTime);
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.sparta.delivery.infrastructure.repository;
+
+import static com.sparta.delivery.domain.model.QDelivery.delivery;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.delivery.domain.model.Delivery;
+import com.sparta.delivery.domain.model.State.DeliveryState;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class DeliveryRepositoryImpl implements DeliveryRepositoryCustom {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Delivery> findDeliveries(UUID shippingManagerId, LocalDateTime requestedDateTime) {
+    return queryFactory
+        .selectFrom(delivery)
+        .where(
+            delivery.shippingManagerId.eq(shippingManagerId), // 배송 담당자 필터링
+            delivery.shippingStartDate.loe(requestedDateTime), // 요청된 날짜보다 이전 또는 같은 날짜
+            delivery.deliveryState.eq(DeliveryState.REQUESTED) // 배송 상태가 REQUESTED
+        )
+        .fetch();
+  }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/DeliveryInternalController.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/DeliveryInternalController.java
@@ -1,0 +1,30 @@
+package com.sparta.delivery.presentation;
+
+import com.sparta.delivery.application.DeliveryFacadeService;
+import com.sparta.delivery.dto.DeliveryDto;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/deliveries")
+@RequiredArgsConstructor
+@Validated
+public class DeliveryInternalController {
+  public final DeliveryFacadeService deliveryFacadeService;
+
+  @GetMapping
+  public List<DeliveryDto> getDeliveriesByShippingManager(
+      @RequestParam("shippingManagerId") @NotNull UUID shippingManagerId,
+      @RequestParam("shippingStartDate") @NotNull LocalDateTime shippingStartDate) {
+    return deliveryFacadeService.findDeliveriesByShippingManagerId(
+        shippingManagerId, shippingStartDate);
+  }
+}

--- a/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/dto/DeliveryRouteResponse.java
+++ b/service/delivery/delivery_server/src/main/java/com/sparta/delivery/presentation/dto/DeliveryRouteResponse.java
@@ -14,7 +14,6 @@ public class DeliveryRouteResponse {
   private RouteState routeState;
   private double estimatedDistance;
   private long estimatedElapsedTime;
-  private Integer realDistance;
   private Duration realElapsedTime;
 
   @Builder
@@ -25,7 +24,6 @@ public class DeliveryRouteResponse {
       UUID arrivalHubId,
       double estimatedDistance,
       long estimatedElapsedTime,
-      Integer realDistance,
       Duration realElapsedTime,
       RouteState routeState) {
     this.deliveryRouteId = deliveryRouteId;
@@ -34,7 +32,6 @@ public class DeliveryRouteResponse {
     this.arrivalHubId = arrivalHubId;
     this.estimatedDistance = estimatedDistance;
     this.estimatedElapsedTime = estimatedElapsedTime;
-    this.realDistance = realDistance;
     this.realElapsedTime = realElapsedTime;
     this.routeState = routeState;
   }
@@ -48,7 +45,6 @@ public class DeliveryRouteResponse {
         .routeState(route.getRouteState())
         .estimatedDistance(route.getEstimatedDistance())
         .estimatedElapsedTime(route.getEstimatedElapsedTime())
-        .realDistance(route.getRealDistance())
         .realElapsedTime(route.getRealElapsedTime())
         .build();
   }

--- a/service/order/order_dto/src/main/java/com/sparta/order/dto/OrderDto.java
+++ b/service/order/order_dto/src/main/java/com/sparta/order/dto/OrderDto.java
@@ -1,0 +1,41 @@
+package com.sparta.order.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderDto {
+  private UUID orderId;
+  private UUID supplierCompanyId;
+  private UUID receiverCompanyId;
+  private UUID managementHubId;
+  private String orderState;
+  private LocalDateTime orderDate;
+  private BigDecimal totalAmount;
+  private int totalQuantity;
+
+  @Builder
+  private OrderDto(
+      UUID orderId,
+      UUID supplierCompanyId,
+      UUID receiverCompanyId,
+      UUID managementHubId,
+      String orderState,
+      LocalDateTime orderDate,
+      BigDecimal totalAmount,
+      int totalQuantity) {
+    this.orderId = orderId;
+    this.supplierCompanyId = supplierCompanyId;
+    this.receiverCompanyId = receiverCompanyId;
+    this.managementHubId = managementHubId;
+    this.orderState = orderState;
+    this.orderDate = orderDate;
+    this.totalAmount = totalAmount;
+    this.totalQuantity = totalQuantity;
+  }
+}

--- a/service/order/order_server/src/main/java/com/sparta/order/application/service/OrderFacadeService.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/application/service/OrderFacadeService.java
@@ -27,7 +27,10 @@ public class OrderFacadeService {
   public OrderResponse create(OrderCreateRequest request) {
     OrderResponse order =
         orderService.create(
-            request.supplierCompanyId(), request.receiverCompanyId(), request.orderDetails());
+            request.supplierCompanyId(),
+            request.receiverCompanyId(),
+            request.managementHubId(),
+            request.orderDetails());
 
     log.info("orderId: {}", order.getOrderId());
     List<ProductDeductDto> productDto = getProductDto(order.getOrderDetails());
@@ -35,8 +38,7 @@ public class OrderFacadeService {
 
     productProducer.send(
         KafkaTopicConstant.DEDUCT_PRODUCT_QUANTITY, order.getOrderId(), productDto);
-    deliveryProducer.send(
-        KafkaTopicConstant.CREATE_DELIVERY, order.getOrderId(), deliveryDto);
+    deliveryProducer.send(KafkaTopicConstant.CREATE_DELIVERY, order.getOrderId(), deliveryDto);
     return order;
   }
 

--- a/service/order/order_server/src/main/java/com/sparta/order/application/service/OrderMapper.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/application/service/OrderMapper.java
@@ -1,0 +1,19 @@
+package com.sparta.order.application.service;
+
+import com.sparta.order.domain.model.Order;
+import com.sparta.order.dto.OrderDto;
+
+public class OrderMapper {
+  public static OrderDto toOrderDto(Order order){
+    return OrderDto.builder()
+        .orderId(order.getOrderId())
+        .supplierCompanyId(order.getSupplierCompanyId())
+        .receiverCompanyId(order.getReceiverCompanyId())
+        .managementHubId(order.getManagementHubId())
+        .totalQuantity(order.getTotalQuantity())
+        .totalAmount(order.getTotalAmount().amount())
+        .orderState(order.getOrderState().name())
+        .orderDate(order.getOrderDate())
+        .build();
+  }
+}

--- a/service/order/order_server/src/main/java/com/sparta/order/application/service/OrderService.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/application/service/OrderService.java
@@ -25,12 +25,13 @@ public class OrderService {
   private final OrderDetailRepository orderDetailRepository;
 
   public OrderResponse create(
-      UUID supplierCompanyId, UUID receiverCompanyId, List<OrderDetailRequest> requests) {
+      UUID supplierCompanyId, UUID receiverCompanyId, UUID managementHubId, List<OrderDetailRequest> requests) {
     Order order =
         Order.builder()
             .supplierCompanyId(supplierCompanyId)
             .receiverCompanyId(receiverCompanyId)
             .orderDate(LocalDateTime.now())
+            .managementHubId(managementHubId)
             .build();
     orderRepository.save(order);
 

--- a/service/order/order_server/src/main/java/com/sparta/order/application/service/OrderService.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/application/service/OrderService.java
@@ -4,6 +4,7 @@ import com.sparta.commons.domain.exception.BusinessException;
 import com.sparta.order.domain.model.Order;
 import com.sparta.order.domain.model.OrderDetail;
 import com.sparta.order.domain.model.OrderState;
+import com.sparta.order.dto.OrderDto;
 import com.sparta.order.infrastructure.repository.OrderDetailRepository;
 import com.sparta.order.infrastructure.repository.OrderRepository;
 import com.sparta.order.presentation.exception.OrderErrorCode;
@@ -14,6 +15,10 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +56,13 @@ public class OrderService {
 
     order.setOrderDetails(orderDetails);
     return OrderResponse.fromEntity(order);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<OrderDto> getOrderListByHubId(UUID managementHubId, int offset, int limit){
+    Pageable pageable = PageRequest.of(offset, limit, Sort.by("orderDate").descending());
+    return orderRepository.findAllByManagementHubId(managementHubId, pageable)
+        .map(OrderMapper::toOrderDto);
   }
 
   public void cancelOrder(UUID orderId) {

--- a/service/order/order_server/src/main/java/com/sparta/order/domain/model/Order.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/domain/model/Order.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -20,11 +21,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
-@Table(name = "P_ORDERS")
+@Table(name = "P_ORDERS",
+    indexes = {
+    @Index(name = "idx_management_hub_id", columnList = "management_hub_id")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_delete is false")
 @SQLDelete(sql = "UPDATE p_orders SET deleted_at = NOW() where order_id = ?")
@@ -54,7 +59,10 @@ public class Order extends BaseEntity {
 
   private int totalQuantity = 0;
 
+  @Column(name = "delivery_id")
   private UUID deliveryId;
+
+  @Column(nullable = false, name = "management_hub_id")
   private UUID managementHubId;
 
   private boolean isDelete = false;

--- a/service/order/order_server/src/main/java/com/sparta/order/domain/model/Order.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/domain/model/Order.java
@@ -55,14 +55,16 @@ public class Order extends BaseEntity {
   private int totalQuantity = 0;
 
   private UUID deliveryId;
+  private UUID managementHubId;
 
   private boolean isDelete = false;
 
   @Builder
-  private Order(UUID supplierCompanyId, UUID receiverCompanyId, LocalDateTime orderDate) {
+  private Order(UUID supplierCompanyId, UUID receiverCompanyId, UUID managementHubId, LocalDateTime orderDate) {
     this.supplierCompanyId = supplierCompanyId;
     this.receiverCompanyId = receiverCompanyId;
     this.orderDate = orderDate;
+    this.managementHubId = managementHubId;
   }
 
   public void setOrderDetails(List<OrderDetail> orderDetailList) {

--- a/service/order/order_server/src/main/java/com/sparta/order/infrastructure/repository/OrderRepository.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/infrastructure/repository/OrderRepository.java
@@ -3,8 +3,11 @@ package com.sparta.order.infrastructure.repository;
 import com.sparta.order.domain.model.Order;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
   Optional<Order> findByOrderId(UUID orderID);
+  Page<Order> findAllByManagementHubId(UUID managementHubId, Pageable pageable);
 }

--- a/service/order/order_server/src/main/java/com/sparta/order/presentation/controller/OrderInternalController.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/presentation/controller/OrderInternalController.java
@@ -1,0 +1,29 @@
+package com.sparta.order.presentation.controller;
+
+import com.sparta.order.application.service.OrderService;
+import com.sparta.order.dto.OrderDto;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/orders")
+@Validated
+public class OrderInternalController {
+  private final OrderService orderService;
+
+  @GetMapping
+  public Page<OrderDto> getOrderListByHubId(
+      @NotNull @RequestParam("managementHubId") UUID hubId,
+      @RequestParam(value = "offset", defaultValue = "0") int offset,
+      @RequestParam(value = "limit", defaultValue = "1000") int limit) {
+    return orderService.getOrderListByHubId(hubId, offset, limit);
+  }
+}

--- a/service/order/order_server/src/main/java/com/sparta/order/presentation/request/OrderCreateRequest.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/presentation/request/OrderCreateRequest.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public record OrderCreateRequest(
     @NotNull(message = "요청업체아이디는 필수입니다") UUID supplierCompanyId,
     @NotNull(message = "수령업체아이디는 필수입니다") UUID receiverCompanyId,
+    @NotNull(message = "관리허브아이디는 필수입니다") UUID managementHubId,
     @Valid @NotNull(message = "주문상품은 필수입니다") List<OrderDetailRequest> orderDetails,
     @NotNull(message = "수령인아이디는 필수입니다") UUID shippingManagerId,
     @NotBlank(message = "수령인의 슬랙아이디는 필수입니다") String shippingManagerSlackId,

--- a/service/order/order_server/src/main/java/com/sparta/order/presentation/response/OrderResponse.java
+++ b/service/order/order_server/src/main/java/com/sparta/order/presentation/response/OrderResponse.java
@@ -17,6 +17,7 @@ public class OrderResponse {
   private UUID orderId;
   private UUID supplierCompanyId;
   private UUID receiverCompanyId;
+  private UUID managementHubId;
   private OrderState orderState;
   private LocalDateTime orderDate;
   private BigDecimal totalAmount;
@@ -28,6 +29,7 @@ public class OrderResponse {
       UUID orderId,
       UUID supplierCompanyId,
       UUID receiverCompanyId,
+      UUID managementHubId,
       OrderState orderState,
       LocalDateTime orderDate,
       List<OrderDetailResponse> details,
@@ -36,6 +38,7 @@ public class OrderResponse {
     this.orderId = orderId;
     this.supplierCompanyId = supplierCompanyId;
     this.receiverCompanyId = receiverCompanyId;
+    this.managementHubId = managementHubId;
     this.orderState = orderState;
     this.orderDate = orderDate;
     this.orderDetails = details;
@@ -48,6 +51,7 @@ public class OrderResponse {
         .orderId(order.getOrderId())
         .supplierCompanyId(order.getSupplierCompanyId())
         .receiverCompanyId(order.getReceiverCompanyId())
+        .managementHubId(order.getManagementHubId())
         .orderState(order.getOrderState())
         .orderDate(order.getOrderDate())
         .details(


### PR DESCRIPTION
### 🌱 작업 사항 
주문/배송쪽에서 사용하는 내부 API 구현
1. 업체배송담당자의 id로 만들어진 배송 중 shippingStartDate가 오늘 이전이면서 상태가 REQUESTED인 배송목록들 가져오기 for 업체배송담당자
2. 특정허브아이디로 주문리스트 가져오기 for 허브담당자
### ❓ 리뷰 포인트
- 1번 API는 조건이 까다로워서 QueryDSL을 사용하였는데, 2번 API는 간단하다고 생각해서 그냥 JPA 쿼리 메소드로 구현하였습니다. 조회 성능 향상을 위해 Order, Delivery에 인덱스를 추가하였습니다
- 두 API 전부 내부 API라 gateway를 거치지않고 각 서비스 엔드포인트로 바로 접근한다고 생각해서 게이트웨이에 라우팅정보를 추가하지 않았습니다 테스트도 각 서비스 엔드포인트로 수행했습니다 
- 1번 메소드는 업체배송담당자가 하루에 1000건이상 배달을 하진 않을것 같아서(count건수가 적다고 생각해서) 그냥 List객체로만 반환했는데 2번 메소드는 몇십만건 이상 조회가 가능하다고 생각해서 limit, offset정보를 requestParam으로 받아서 처리했습니다. 근데 2번도 내부 API라서 결과값을 페이지 객체로 감싸서 반환할 필요가 없다고 생각했으나.. 전체 데이터 건수를 확인해야 offset과 limit 값을 조정해서 요청할 수 있으니 결국  페이지 객체에 감싸서 리턴하는것으로 처리했습니다. 이부분에 대한 생각이 어떠신지 궁금합니다.
- 테스트
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/910825be-0a17-43ff-9d30-57a11f9d4d07">
shippingManagerId, shippingStartDate, deliveryState가 REQUESTED인 건들의 베송 리스트 조회
<img width="863" alt="image" src="https://github.com/user-attachments/assets/93e19498-c0bf-47c1-bacc-fbf623ee3453">
managementHubId, limit(default=1000), offset(default=0)인 건들의 주문 리스트 조회

### 🦄 관련 이슈
resolves #40 
